### PR TITLE
Fixed sort to allow explicitly setting "asc" or "desc" direction

### DIFF
--- a/src/PlainElastic.Net.Tests/Buildres/Commands/SearchCommand/When_SearchCommand_with_default_sort_direction_built.cs
+++ b/src/PlainElastic.Net.Tests/Buildres/Commands/SearchCommand/When_SearchCommand_with_default_sort_direction_built.cs
@@ -1,0 +1,23 @@
+﻿using Machine.Specifications;
+
+namespace PlainElastic.Net.Tests.Buildres.Commands
+{
+    [Subject(typeof(SearchCommand))]
+    class When_SearchCommand_with_default_sort_direction_built
+    {
+
+        Because of = () => result = new SearchCommand(index:"Index", type:"Type")
+            .Sort("name")
+            .BuildCommand();
+
+
+        It should_starts_with_index_type = () => result.ShouldStartWith("index/type");
+
+        It should_contain_first_parameter_sort_with_name = () => result.ShouldContain("?sort=name");
+
+        It should_return_correct_value = () => result.ShouldEqual(@"index/type/_search?sort=name");
+
+
+        private static string result;
+    }
+}

--- a/src/PlainElastic.Net.Tests/Buildres/Commands/SearchCommand/When_SearchCommand_with_reflected_sort_fields_built.cs
+++ b/src/PlainElastic.Net.Tests/Buildres/Commands/SearchCommand/When_SearchCommand_with_reflected_sort_fields_built.cs
@@ -7,15 +7,15 @@ namespace PlainElastic.Net.Tests.Buildres.Commands
     {
 
         Because of = () => result = new SearchCommand(index:"Index", type:"Type")
-            .Sort<FieldsTestClass>(c => c.StringProperty, SortDirection.ask)
+            .Sort<FieldsTestClass>(c => c.StringProperty, SortDirection.asc)
             .BuildCommand();
 
 
         It should_starts_with_index_type = () => result.ShouldStartWith("index/type");
 
-        It should_contain_first_parameter_sort_with_StringProperty_ask = () => result.ShouldContain("?sort=StringProperty:ask");
+        It should_contain_first_parameter_sort_with_StringProperty_ask = () => result.ShouldContain("?sort=StringProperty:asc");
 
-        It should_return_correct_value = () => result.ShouldEqual(@"index/type/_search?sort=StringProperty:ask");
+        It should_return_correct_value = () => result.ShouldEqual(@"index/type/_search?sort=StringProperty:asc");
 
 
         private static string result;

--- a/src/PlainElastic.Net.Tests/Buildres/Queries/Sort/When_Sort_with_default_order_built.cs
+++ b/src/PlainElastic.Net.Tests/Buildres/Queries/Sort/When_Sort_with_default_order_built.cs
@@ -1,0 +1,22 @@
+﻿using Machine.Specifications;
+using PlainElastic.Net.Queries;
+using PlainElastic.Net.Utils;
+
+namespace PlainElastic.Net.Tests.Buildres.Queries
+{
+    [Subject(typeof(Sort<>))]
+    class When_Sort_with_default_order_built
+    {
+        Because of = () => result = new Sort<FieldsTestClass>()
+                                                .Field("field", order: SortDirection.@default, missing: "_last")
+                                                .ToString();
+
+        It should_not_contain_order_part = () => result.ShouldNotContain("order");
+
+        It should_contain_correct_missing_value = () => result.ShouldContain("'missing': '_last'".AltQuote());
+
+        It should_return_correct_value = () => result.ShouldEqual("'sort': [{ 'field': { 'missing': '_last' } }]".AltQuote());
+
+        private static string result;
+    }
+}

--- a/src/PlainElastic.Net.Tests/Buildres/Queries/Sort/When_Sort_with_desc_order_built.cs
+++ b/src/PlainElastic.Net.Tests/Buildres/Queries/Sort/When_Sort_with_desc_order_built.cs
@@ -11,11 +11,11 @@ namespace PlainElastic.Net.Tests.Buildres.Queries
                                                 .Field("field", order: SortDirection.desc, missing: "_last")
                                                 .ToString();
 
-        It should_not_contain_order_part = () => result.ShouldNotContain("order");
+        It should_contain_correct_order = () => result.ShouldContain(@"'order': 'desc'".AltQuote());
 
         It should_contain_correct_missing_value = () => result.ShouldContain("'missing': '_last'".AltQuote());
 
-        It should_return_correct_value = () => result.ShouldEqual("'sort': [{ 'field': { 'missing': '_last' } }]".AltQuote());
+        It should_return_correct_value = () => result.ShouldEqual("'sort': [{ 'field': { 'order': 'desc','missing': '_last' } }]".AltQuote());
 
         private static string result;
     }

--- a/src/PlainElastic.Net.Tests/Buildres/Queries/Sort/When_Sort_with_reflected_field_built.cs
+++ b/src/PlainElastic.Net.Tests/Buildres/Queries/Sort/When_Sort_with_reflected_field_built.cs
@@ -8,14 +8,14 @@ namespace PlainElastic.Net.Tests.Buildres.Queries
     class When_Sort_with_reflected_field_built
     {
         Because of = () => result = new Sort<FieldsTestClass>()
-                                                .Field(f => f.StringProperty, order: SortDirection.ask, missing: "_last")
+                                                .Field(f => f.StringProperty, order: SortDirection.asc, missing: "_last")
                                                 .ToString();
 
-        It should_contain_correct_order = () => result.ShouldContain(@"'order': 'ask'".AltQuote());
+        It should_contain_correct_order = () => result.ShouldContain(@"'order': 'asc'".AltQuote());
 
         It should_contain_correct_missing_value = () => result.ShouldContain(@"'missing': '_last'".AltQuote());
 
-        It should_return_correct_value = () => result.ShouldEqual(@"'sort': [{ 'StringProperty': { 'order': 'ask','missing': '_last' } }]".AltQuote());
+        It should_return_correct_value = () => result.ShouldEqual(@"'sort': [{ 'StringProperty': { 'order': 'asc','missing': '_last' } }]".AltQuote());
 
         private static string result;
     }

--- a/src/PlainElastic.Net.Tests/PlainElastic.Net.Tests.csproj
+++ b/src/PlainElastic.Net.Tests/PlainElastic.Net.Tests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Buildres\Commands\OptimizeCommand\When_complete_OptimizeCommand_built.cs" />
     <Compile Include="Buildres\Commands\CountCommand\When_complete_CountCommand_built.cs" />
     <Compile Include="Buildres\Commands\CountCommand\When_CountCommand_with_multiple_indexes_and_types_built.cs" />
+    <Compile Include="Buildres\Commands\SearchCommand\When_SearchCommand_with_default_sort_direction_built.cs" />
     <Compile Include="Buildres\Commands\UpdateSettingsCommand\When_complete_UpdateSettingsCommand_built.cs" />
     <Compile Include="Buildres\Commands\PutMappingCommand\When_complete_PutMappingCommand_built.cs" />
     <Compile Include="Buildres\Commands\PutMappingCommand\When_PutMappingCommand_with_multiple_indexes_built.cs" />
@@ -118,6 +119,7 @@
     <Compile Include="Buildres\Mappings\Object\When_complete_Object_mapping_built.cs" />
     <Compile Include="Buildres\Mappings\Object\When_Object_with_custom_property_built.cs" />
     <Compile Include="Buildres\Queries\Bool\When_BoolQuery_with_useActualShouldCount_built.cs" />
+    <Compile Include="Buildres\Queries\Sort\When_Sort_with_default_order_built.cs" />
     <Compile Include="Buildres\Queries\TextPhrasePrefix\When_complete_TextPhrasePrefixQuery_built.cs" />
     <Compile Include="Buildres\Queries\TextPhrasePrefix\When_TextPhrasePrefixQuery_without_query_built.cs" />
     <Compile Include="Buildres\Queries\TextPhrase\When_complete_TextPhraseQuery_built.cs" />

--- a/src/PlainElastic.Net/Builders/Commands/Enums.cs
+++ b/src/PlainElastic.Net/Builders/Commands/Enums.cs
@@ -10,7 +10,7 @@ namespace PlainElastic.Net
 
     public enum DocumentReplication { sync, async }
 
-    public enum SortDirection { ask, desc }
+    public enum SortDirection { @default, asc, desc }
 
     public enum SearchType { query_and_fetch, query_then_fetch, dfs_query_and_fetch, dfs_query_then_fetch, count, scan }
 

--- a/src/PlainElastic.Net/Builders/Commands/SearchCommand.cs
+++ b/src/PlainElastic.Net/Builders/Commands/SearchCommand.cs
@@ -179,20 +179,23 @@ namespace PlainElastic.Net
         /// Sorting to perform. There can be several Sort parameters (order is important).
         /// Use "_score" to sort by query score.
         /// </summary>
-        public SearchCommand Sort(string fieldname, SortDirection direction)
+        public SearchCommand Sort(string fieldname, SortDirection direction = SortDirection.@default)
         {
-            Parameters.Add("sort", fieldname + ":" + direction.ToString());
-            return this;            
+            string value = fieldname;
+            if (direction != SortDirection.@default)
+                value += ":" + direction.ToString();
+
+            Parameters.Add("sort", value);
+            return this;
         }
 
         /// <summary>
         /// Sorting to perform. There can be several Sort parameters (order is important).
         /// </summary>
-        public SearchCommand Sort<T>(Expression<Func<T, object>> property, SortDirection direction)
+        public SearchCommand Sort<T>(Expression<Func<T, object>> property, SortDirection direction = SortDirection.@default)
         {
             string fieldname = property.GetPropertyPath();
-            Parameters.Add("sort", fieldname + ":" + direction.ToString());
-            return this;            
+            return Sort(fieldname, direction);
         }
 
 

--- a/src/PlainElastic.Net/Builders/Queries/Sort.cs
+++ b/src/PlainElastic.Net/Builders/Queries/Sort.cs
@@ -15,10 +15,10 @@ namespace PlainElastic.Net.Queries
         /// There can be several Sort parameters (order is important).
         /// </summary>
         /// <param name="field">The field.</param>
-        /// <param name="order">The sort order. By default descendant.</param>
+        /// <param name="order">The sort order. By default order depends on chosen field (descending for "_scope", ascending for others) and field analyzer.</param>
         /// <param name="missing">The missing value handling strategy. Use _last, _first or custom value.</param>
         /// <returns></returns>
-        public Sort<T> Field(Expression<Func<T, object>> field, SortDirection order = SortDirection.desc, string missing = null)
+        public Sort<T> Field(Expression<Func<T, object>> field, SortDirection order = SortDirection.@default, string missing = null)
         {
             var fieldName = field.GetPropertyPath();
             
@@ -30,13 +30,13 @@ namespace PlainElastic.Net.Queries
         /// There can be several Sort parameters (order is important).
         /// </summary>
         /// <param name="field">The field. Use _score to sort by score.</param>
-        /// <param name="order">The sort order. By default descendant.</param>
+        /// <param name="order">The sort order. By default order depends on chosen field (descending for "_scope", ascending for others) and field analyzer.</param>
         /// <param name="missing">The missing value handling strategy. Use _last, _first or custom value.</param>
         /// <returns></returns>
-        public Sort<T> Field(string field, SortDirection order = SortDirection.desc, string missing = null)
+        public Sort<T> Field(string field, SortDirection order = SortDirection.@default, string missing = null)
         {
             var fieldParams = new List<string>();
-            if (order != SortDirection.desc)
+            if (order != SortDirection.@default)
                 fieldParams.Add("'order': {0}".AltQuoteF(order.ToString().Quotate()));
 
             if (!missing.IsNullOrEmpty())


### PR DESCRIPTION
elasticsearch sort direction defaults not to "desc" but to field defaults (desc for "_score", asc for others) and also depends on field analyzer. Fixed for QueryBuilder<T>.Sort() and SearchCommand.Sort()
