### PR TITLE
"Status" command "size in bytes" fields type fix - they should be of type "long"

### DIFF
--- a/src/PlainElastic.Net.Tests/Serialization/When_status_command_result_deserialized.cs
+++ b/src/PlainElastic.Net.Tests/Serialization/When_status_command_result_deserialized.cs
@@ -20,9 +20,9 @@ namespace PlainElastic.Net.Tests.Serialization
         'twitter': {
             'index': {
                 'primary_size': '430b',
-                'primary_size_in_bytes': 430,
+                'primary_size_in_bytes': 5000000000,
                 'size': '430b',
-                'size_in_bytes': 430
+                'size_in_bytes': 5000000000
             },
             'translog': {
                 'operations': 5
@@ -152,8 +152,11 @@ namespace PlainElastic.Net.Tests.Serialization
         It should_contain_twitter_index = () =>
             result.indices["twitter"].ShouldNotBeNull();
 
-        It should_contain_correct_twitter_index_size = () =>
-            result.indices["twitter"].index.size_in_bytes.ShouldEqual(430);
+        It should_contain_correct_twitter_index_primary_size_in_bytes = () =>
+            result.indices["twitter"].index.primary_size_in_bytes.ShouldEqual(5000000000);
+
+        It should_contain_correct_twitter_index_size_in_bytes = () =>
+            result.indices["twitter"].index.size_in_bytes.ShouldEqual(5000000000);
 
         It should_contain_correct_translog_operations = () =>
             result.indices["twitter"].translog.operations.ShouldEqual(5);

--- a/src/PlainElastic.Net/Serialization/Results/StatusResult.cs
+++ b/src/PlainElastic.Net/Serialization/Results/StatusResult.cs
@@ -53,7 +53,7 @@ namespace PlainElastic.Net.Serialization
     public class SnapshotIndexStats
     {
         public string size;
-        public int size_in_bytes;
+        public long size_in_bytes;
     }
 
     public class GatewayRecoveryStats
@@ -75,13 +75,13 @@ namespace PlainElastic.Net.Serialization
     {
         public int progress;
         public string size;
-        public int size_in_bytes;
+        public long size_in_bytes;
         public string reused_size;
-        public int reused_size_in_bytes;
+        public long reused_size_in_bytes;
         public string expected_recovered_size;
-        public int expected_recovered_size_in_bytes;
+        public long expected_recovered_size_in_bytes;
         public string recovered_size;
-        public int recovered_size_in_bytes;
+        public long recovered_size_in_bytes;
     }
 
     public class RoutingStats
@@ -113,13 +113,13 @@ namespace PlainElastic.Net.Serialization
         public int current;
         public int current_docs;
         public string current_size;
-        public int current_size_in_bytes;
+        public long current_size_in_bytes;
         public int total;
         public string total_time;
         public int total_time_in_millis;
         public int total_docs;
         public string total_size;
-        public int total_size_in_bytes;
+        public long total_size_in_bytes;
     }
 
     public class DocsStats
@@ -138,8 +138,8 @@ namespace PlainElastic.Net.Serialization
     public class IndexStats
     {
         public string primary_size;
-        public int primary_size_in_bytes;
+        public long primary_size_in_bytes;
         public string size;
-        public int size_in_bytes;
+        public long size_in_bytes;
     }
 }


### PR DESCRIPTION
For "Status" command index size in bytes (and other "size in bytes" fields) can exceed int.MaxValue. Fixed fields to be of type long (System.Int64)
