### PR TITLE
Increased web request speed by forcing the proxy to be assigned.

### DIFF
--- a/src/PlainElastic.Net/Connection/ElasticConnection.cs
+++ b/src/PlainElastic.Net/Connection/ElasticConnection.cs
@@ -107,9 +107,7 @@ namespace PlainElastic.Net
             request.Timeout = 60 * 1000;
             request.ReadWriteTimeout = 60 * 1000;
             request.Method = method;
-
-            if (Proxy != null )
-                request.Proxy = Proxy;
+            request.Proxy = Proxy;
 
             if (Credentials != null)
                 request.Credentials = Credentials;


### PR DESCRIPTION
Removed if statement around request proxy assignation, assigning null
ensures the request does not hunt around for a proxy.
