### PR TITLE
Adding support for configuring the number of shards and replicas

### DIFF
--- a/src/PlainElastic.Net.Tests/Builders/IndexSettings/When_complete_IndexSettingsBuilder_built.cs
+++ b/src/PlainElastic.Net.Tests/Builders/IndexSettings/When_complete_IndexSettingsBuilder_built.cs
@@ -9,12 +9,14 @@ namespace PlainElastic.Net.Tests.Builders.IndexSettings
     {
         Because of = () => result = new IndexSettingsBuilder()
                                             .Analysis(a => a.CustomPart("Analysis"))
+                                            .Settings(a => a.CustomPart("Settings"))
                                             .Build();
 
         It should_contain_analysis_part = () => result.ShouldContain("'analysis': { Analysis }".AltQuote());
-        
-        It should_return_correct_result = () => result.ShouldEqual(("{ 'index': { " +
-                                                                    "'analysis': { Analysis } } }").AltQuote());
+
+        It should_contain_settings_part = () => result.ShouldContain("Settings");
+
+        It should_return_correct_result = () => result.ShouldEqual(("{ 'settings': { 'index': { 'analysis': { Analysis },Settings } } }").AltQuote());
 
         private static string result;
     }

--- a/src/PlainElastic.Net.Tests/Builders/Settings/When_settings_builder_has_replicas.cs
+++ b/src/PlainElastic.Net.Tests/Builders/Settings/When_settings_builder_has_replicas.cs
@@ -1,0 +1,16 @@
+﻿using Machine.Specifications;
+
+using PlainElastic.Net.Builders.IndexSettings.Settings;
+using PlainElastic.Net.Utils;
+
+namespace PlainElastic.Net.Tests.Builders.Settings
+{
+    public class When_settings_builder_has_replicas
+    {
+        private static string result;
+
+        Because of = () => result = new Setting().NumberOfReplicas(3).ToString();
+
+        It should_contain_the_number_of_replicas = () => result.ShouldContain("'number_of_replicas': 3".AltQuote());
+    }
+}

--- a/src/PlainElastic.Net.Tests/Builders/Settings/When_settings_builder_has_shards.cs
+++ b/src/PlainElastic.Net.Tests/Builders/Settings/When_settings_builder_has_shards.cs
@@ -1,0 +1,16 @@
+﻿using Machine.Specifications;
+
+using PlainElastic.Net.Builders.IndexSettings.Settings;
+using PlainElastic.Net.Utils;
+
+namespace PlainElastic.Net.Tests.Builders.Settings
+{
+    public class When_settings_builder_has_shards
+    {
+        private static string result;
+
+        Because of = () => result = new Setting().NumberOfShards(2).ToString();
+
+        It should_contain_the_number_of_replicas = () => result.ShouldContain("'number_of_shards': 2".AltQuote());
+    }
+}

--- a/src/PlainElastic.Net.Tests/Builders/Settings/When_settings_builder_has_shards_and_a_replica.cs
+++ b/src/PlainElastic.Net.Tests/Builders/Settings/When_settings_builder_has_shards_and_a_replica.cs
@@ -1,0 +1,16 @@
+﻿using Machine.Specifications;
+
+using PlainElastic.Net.Builders.IndexSettings.Settings;
+using PlainElastic.Net.Utils;
+
+namespace PlainElastic.Net.Tests.Builders.Settings
+{
+    public class When_settings_builder_has_shards_and_a_replica
+    {
+        private static string result;
+
+        Because of = () => result = new Setting().NumberOfReplicas(3).NumberOfShards(2).ToString();
+
+        It should_contain_the_number_of_replicas = () => result.ShouldContain("'number_of_replicas': 3,'number_of_shards': 2".AltQuote());
+    }
+}

--- a/src/PlainElastic.Net.Tests/Builders/Settings/When_settings_builder_is_empty.cs
+++ b/src/PlainElastic.Net.Tests/Builders/Settings/When_settings_builder_is_empty.cs
@@ -1,0 +1,17 @@
+﻿using Machine.Specifications;
+
+using PlainElastic.Net.Builders.IndexSettings.Settings;
+using PlainElastic.Net.Utils;
+
+namespace PlainElastic.Net.Tests.Builders.Settings
+{
+    [Subject(typeof(Setting))]
+    public class When_settings_builder_is_empty
+    {
+        private static string result;
+
+        Because of = () => result = new Setting().ToString();
+
+        private It should_contain_no_settings_part = () => result.ShouldContain("".AltQuote());
+    }
+}

--- a/src/PlainElastic.Net.Tests/PlainElastic.Net.Tests.csproj
+++ b/src/PlainElastic.Net.Tests/PlainElastic.Net.Tests.csproj
@@ -375,6 +375,10 @@
     <Compile Include="Builders\Queries\Query\When_Query_with_empty_subqueries_built.cs" />
     <Compile Include="Builders\Queries\QueryString\When_QueryString_Query_called_for_html_injection.cs" />
     <Compile Include="Builders\Queries\_Highlight\When_highlighted_part_built.cs" />
+    <Compile Include="Builders\Settings\When_settings_builder_has_replicas.cs" />
+    <Compile Include="Builders\Settings\When_settings_builder_has_shards.cs" />
+    <Compile Include="Builders\Settings\When_settings_builder_has_shards_and_a_replica.cs" />
+    <Compile Include="Builders\Settings\When_settings_builder_is_empty.cs" />
     <Compile Include="Connection\When_CreateRequest_with_null_Proxy_called.cs" />
     <Compile Include="Connection\When_CreateRequest_with_no_Proxy_specified_called.cs" />
     <Compile Include="Connection\When_CreateRequest_with_Credentials_called.cs" />

--- a/src/PlainElastic.Net/Builders/IndexSettings/IndexSettingsBuilder.cs
+++ b/src/PlainElastic.Net/Builders/IndexSettings/IndexSettingsBuilder.cs
@@ -1,17 +1,16 @@
 using System;
 using PlainElastic.Net.Builders;
+using PlainElastic.Net.Builders.IndexSettings.Settings;
 using PlainElastic.Net.Utils;
 
 namespace PlainElastic.Net.IndexSettings
 {
-
     /// <summary>
     /// Allows to build index level settings.
     /// see: http://www.elasticsearch.org/guide/reference/api/admin-indices-update-settings.html
     /// </summary>
     public class IndexSettingsBuilder : SettingsBase<IndexSettingsBuilder>
     {
-
         /// <summary>
         /// The index analysis module acts as a configurable registry of Analyzers
         /// that can be used in order to both break indexed (analyzed) fields when a document is indexed and process query strings.
@@ -24,20 +23,15 @@ namespace PlainElastic.Net.IndexSettings
             return this;
         }
 
-
-        protected override string ApplyJsonTemplate(string body)
+        public IndexSettingsBuilder Settings(Func<Setting, Setting> settings)
         {
-            if (body.IsNullOrEmpty())
-                return "";
-
-            return "{{ 'index': {{ {0} }} }}".AltQuoteF(body);
+            RegisterJsonPartExpression(settings);
+            return this;
         }
-
-
 
         public string Build()
         {
-            return ((IJsonConvertible) this).ToJson();
+            return ((IJsonConvertible)this).ToJson();
         }
 
         public string BuildBeautified()
@@ -45,10 +39,17 @@ namespace PlainElastic.Net.IndexSettings
             return Build().BeautifyJson();
         }
 
-
         public override string ToString()
         {
             return BuildBeautified();
+        }
+
+        protected override string ApplyJsonTemplate(string body)
+        {
+            if (body.IsNullOrEmpty())
+                return "";
+
+            return "{{ 'settings': {{ 'index': {{ {0} }} }} }}".AltQuoteF(body);
         }
     }
 }

--- a/src/PlainElastic.Net/Builders/IndexSettings/Settings/Setting.cs
+++ b/src/PlainElastic.Net/Builders/IndexSettings/Settings/Setting.cs
@@ -1,0 +1,25 @@
+﻿using PlainElastic.Net.IndexSettings;
+using PlainElastic.Net.Utils;
+
+namespace PlainElastic.Net.Builders.IndexSettings.Settings
+{
+    public class Setting : SettingsBase<Setting>
+    {
+        public Setting NumberOfShards(int number)
+        {
+            RegisterJsonPart("'number_of_shards': {0}", number.AsString());
+            return this;
+        }
+
+        public Setting NumberOfReplicas(int number)
+        {
+            RegisterJsonPart("'number_of_replicas': {0}", number.AsString());
+            return this;
+        }
+
+        protected override string ApplyJsonTemplate(string body)
+        {
+            return body.AltQuote();
+        }
+    }
+}

--- a/src/PlainElastic.Net/PlainElastic.Net.csproj
+++ b/src/PlainElastic.Net/PlainElastic.Net.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Builders\IndexSettings\Analysis\Analyzers\WhitespaceAnalyzer.cs" />
     <Compile Include="Builders\IndexSettings\Analysis\Enums.cs" />
     <Compile Include="Builders\IndexSettings\IndexSettingsBuilder.cs" />
+    <Compile Include="Builders\IndexSettings\Settings\Setting.cs" />
     <Compile Include="Builders\Mappings\Attachment.cs" />
     <Compile Include="Builders\Mappings\Core\ElasticCoreTypeMapper.cs" />
     <Compile Include="Builders\Mappings\Core\CustomPropertyMap.cs" />


### PR DESCRIPTION
In order to create a highly available search cluster
As a developer
I want to be able to specify the number of shards and number of replicas when I create an Index
