### PR TITLE
Allow later versions of newtonsoft to be used

### DIFF
--- a/src/PlainElastic.Net/packages.config
+++ b/src/PlainElastic.Net/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.0.7" />
+  <package id="Newtonsoft.Json" version="4.0" />
 </packages>


### PR DESCRIPTION
Restricting to patch release can cause package collisions. This tiny change allows later version of newtonsoft.json to fulfil the dependency.