### PR TITLE
Removed "type: object" from the rootobject type

### DIFF
--- a/src/PlainElastic.Net.Tests/Builders/Mappings/RootObject/When_RootObject_mapping_with_NestedProperty_built.cs
+++ b/src/PlainElastic.Net.Tests/Builders/Mappings/RootObject/When_RootObject_mapping_with_NestedProperty_built.cs
@@ -1,0 +1,33 @@
+﻿using Machine.Specifications;
+using PlainElastic.Net.Mappings;
+using PlainElastic.Net.Utils;
+
+
+namespace PlainElastic.Net.Tests.Builders.Mappings
+{
+    [Subject(typeof(Object<>))]
+    class When_RootObject_mapping_with_NestedProperty_built
+    {
+        Because of = () => result = new RootObject<FieldsTestClass>()
+                                                .Field("TestObject")
+                                                .Properties(p => p.NestedObject(f => f.ObjectProperty, opt => opt.IncludeInAll(false).Enabled(true)))
+                                                .ToString();
+
+        It should_start_from_specified_field_name = () => result.ShouldStartWith("'TestObject': {".AltQuote());
+
+        It should_not_contain_object_type_declaration_part = () => result.ShouldNotContain("'type': 'object'".AltQuote());
+
+        It should_contain_properties_mapping_part = () => result.ShouldContain("'properties': { ".AltQuote());
+
+        It should_contain_binary_property_mapping_part = () => result.ShouldContain("'ObjectProperty': { 'type': 'nested','include_in_all': false,'enabled': true }".AltQuote());
+
+
+        It should_generate_correct_JSON_result = () => result.ShouldEqual(("'TestObject': { " +
+                                                                            "'properties': { " +
+                                                                               "'ObjectProperty': { 'type': 'nested','include_in_all': false,'enabled': true } " +
+                                                                            "} " +
+                                                                          "}").AltQuote());
+
+        private static string result;
+    }
+}

--- a/src/PlainElastic.Net.Tests/Builders/Mappings/RootObject/When_simplest_RootObject_mapping_built.cs
+++ b/src/PlainElastic.Net.Tests/Builders/Mappings/RootObject/When_simplest_RootObject_mapping_built.cs
@@ -1,0 +1,24 @@
+﻿using Machine.Specifications;
+using PlainElastic.Net.Mappings;
+using PlainElastic.Net.Utils;
+
+
+namespace PlainElastic.Net.Tests.Builders.Mappings
+{
+    [Subject(typeof(Object<>))]
+    class When_simplest_RootObject_mapping_built
+    {
+        Because of = () => result = new RootObject<FieldsTestClass>()
+                                                .Field("TestObject")
+                                                .ToString();
+
+        It should_start_from_specified_field_name = () => result.ShouldStartWith("'TestObject': {".AltQuote());
+
+        It should_contain_object_type_declaration_part = () => result.ShouldContain("'type': 'object'".AltQuote());
+
+
+        It should_generate_correct_JSON_result = () => result.ShouldEqual(("'TestObject': { 'type': 'object' }").AltQuote());
+
+        private static string result;
+    }
+}

--- a/src/PlainElastic.Net.Tests/PlainElastic.Net.Tests.csproj
+++ b/src/PlainElastic.Net.Tests/PlainElastic.Net.Tests.csproj
@@ -237,6 +237,8 @@
     <Compile Include="Builders\Mappings\Object\When_Object_with_enum_property_mapping_built.cs" />
     <Compile Include="Builders\Mappings\Object\When_complete_Object_mapping_built.cs" />
     <Compile Include="Builders\Mappings\Object\When_Object_with_custom_property_built.cs" />
+    <Compile Include="Builders\Mappings\RootObject\When_RootObject_mapping_with_NestedProperty_built.cs" />
+    <Compile Include="Builders\Mappings\RootObject\When_simplest_RootObject_mapping_built.cs" />
     <Compile Include="Builders\Queries\Bool\When_BoolQuery_with_useActualShouldCount_built.cs" />
     <Compile Include="Builders\Queries\Boosting\When_complete_BoostingQuery_built.cs" />
     <Compile Include="Builders\Queries\Boosting\When_empty_BoostingQuery_built.cs" />

--- a/src/PlainElastic.Net/Builders/Mappings/Object.cs
+++ b/src/PlainElastic.Net/Builders/Mappings/Object.cs
@@ -4,8 +4,7 @@ namespace PlainElastic.Net.Mappings
     /// Builds a mapping that allows to map inner JSON object. 
     /// http://www.elasticsearch.org/guide/reference/mapping/object-type.html
     /// </summary>
-    public class Object<T>: ObjectBase<T,Object<T>>
+    public class Object<T> : ObjectBase<T, Object<T>>
     {
-
     }
 }

--- a/src/PlainElastic.Net/Builders/Mappings/RootObject.cs
+++ b/src/PlainElastic.Net/Builders/Mappings/RootObject.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Linq;
+
 using PlainElastic.Net.Utils;
 
 namespace PlainElastic.Net.Mappings
@@ -135,6 +135,13 @@ namespace PlainElastic.Net.Mappings
             return this;
         }
 
+        protected override string ApplyMappingTemplate(string mappingBody)
+        {
+            if (mappingBody.IsNullOrEmpty())
+                return "{0}: {{ 'type': 'object' }}".AltQuoteF(Name.Quotate());
+
+            return "{0}: {{ {1} }}".AltQuoteF(Name.Quotate(), mappingBody);
+        }
         
         /*
         public Type<T> Type;


### PR DESCRIPTION
Since ElasticSearch 1.2+ - the 'type: object' property is invalid and causes an error when creating a mapping.

This fix patches this on the RootObject class. This fix has been tested on ElasticSearch versions 0.90.7, 1.2.2 and 1.3.1
